### PR TITLE
CFPリンクとページを非表示に、チケット購入リンク類の復活

### DIFF
--- a/nuxt_src/components/parts/TheHeader.vue
+++ b/nuxt_src/components/parts/TheHeader.vue
@@ -86,44 +86,46 @@
             <!-- {{ $t('login') }} -->
             <!-- </nuxt-link> -->
             <!-- </div> -->
-            <!-- <div class="function_item function_item-application"> -->
-            <!-- <a href="https://scalaconfjp.doorkeeper.jp/events/103550" target="_blank" rel="noopener"> -->
-            <!-- {{ $t('ticket') }} -->
-            <!-- </a> -->
-            <!-- </div> -->
-            <li class="function_item function_item-login">
+            <li class="function_item function_item-application">
+              <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener">
+                {{ $t('ticket') }}
+              </a>
+            </li>
+            <!-- <li class="function_item function_item-login">
               <nuxt-link :to="localePath('cfp')">
                 {{ $t('cfp') }}
               </nuxt-link>
-            </li>
+            </li> -->
           </ul>
-          <!-- ログイン前 ここまで -->
-          <!-- ログイン後 ここから -->
-          <!-- <ul v-else-if="isLoggedIn" class="function"> -->
-          <!-- <li class="function_item function_item-userIcon"> -->
-          <!-- <div class="userMenu js-myMenu"> -->
-          <!-- <div class="function_userIcon js-myMenuIcon" :style="`background-image: url(${auth.profile.photoURL})`" @click="toggleUserMenu()" /> -->
-          <!-- <ul v-if="userMenuActive" class="userMenu_list js-myMenuList"> -->
-          <!-- <li class="userMenu_list_item" @click="logout()"> -->
-          <!-- {{ $t('logout') }} -->
-          <!-- </li> -->
-          <!-- </ul> -->
-          <!-- </div> -->
-          <!-- </li> -->
-          <!-- <li class="function_item function_item-login"> -->
-          <!-- <nuxt-link :to="localePath('cfp')"> -->
-          <!-- {{ $t('cfp') }} -->
-          <!-- </nuxt-link> -->
-          <!-- </li> -->
-          <!-- <li class="function_item function_item-application"> -->
-          <!-- <a href="https://scalaconfjp.doorkeeper.jp/events/103550" target="_blank" rel="noopener"> -->
-          <!-- {{ $t('ticket') }} -->
-          <!-- </a> -->
-          <!-- </li> -->
-          <!-- </ul> -->
-          <!-- ログイン後 ここまで -->
         </div>
+        </ul>
+        <!-- ログイン前 ここまで -->
+        <!-- ログイン後 ここから -->
+        <!-- <ul v-else-if="isLoggedIn" class="function"> -->
+        <!-- <li class="function_item function_item-userIcon"> -->
+        <!-- <div class="userMenu js-myMenu"> -->
+        <!-- <div class="function_userIcon js-myMenuIcon" :style="`background-image: url(${auth.profile.photoURL})`" @click="toggleUserMenu()" /> -->
+        <!-- <ul v-if="userMenuActive" class="userMenu_list js-myMenuList"> -->
+        <!-- <li class="userMenu_list_item" @click="logout()"> -->
+        <!-- {{ $t('logout') }} -->
+        <!-- </li> -->
+        <!-- </ul> -->
+        <!-- </div> -->
+        <!-- </li> -->
+        <!-- <li class="function_item function_item-login"> -->
+        <!-- <nuxt-link :to="localePath('cfp')"> -->
+        <!-- {{ $t('cfp') }} -->
+        <!-- </nuxt-link> -->
+        <!-- </li> -->
+        <!-- <li class="function_item function_item-application"> -->
+        <!-- <a href="https://scalaconfjp.doorkeeper.jp/events/103550" target="_blank" rel="noopener"> -->
+        <!-- {{ $t('ticket') }} -->
+        <!-- </a> -->
+        <!-- </li> -->
+        <!-- </ul> -->
+        <!-- ログイン後 ここまで -->
       </div>
+    </div>
     </div>
     <!-- グローバルナビ PC ここまで -->
     <!-- グローバルナビ SP ここから -->
@@ -183,11 +185,11 @@
                   {{ $t('login') }}
                 </nuxt-link>
               </div> -->
-              <!-- <div class="function_item function_item-application">
-                <a href="https://scalaconfjp.doorkeeper.jp/events/103550" target="_blank" rel="noopener">
+              <div class="function_item function_item-application">
+                <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener">
                   {{ $t('ticket') }}
                 </a>
-              </div> -->
+              </div>
               <!-- <div class="function_item function_item-login" @click="toggleMenu()">
                 <nuxt-link :to="localePath('cfp')">
                   {{ $t('cfp') }}

--- a/nuxt_src/components/sections/top/banner.vue
+++ b/nuxt_src/components/sections/top/banner.vue
@@ -28,7 +28,7 @@ ja:
         <span>{{ $t('cfp') }}</span>
       </nuxt-link> -->
       <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener" class="banner_item banner_item-staff">
-        <span>{{ $t('doorkeeper') }}</span>
+        <span>{{ $t('ticket') }}</span>
       </a>
     </div>
   </div>

--- a/nuxt_src/components/sections/top/banner.vue
+++ b/nuxt_src/components/sections/top/banner.vue
@@ -24,12 +24,12 @@ ja:
       <!-- <a :href="$t('tshirt_url')" class="banner_item banner_item-tshirt">
         <span>{{ $t('tshirt') }} </span>
       </a> -->
-      <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff">
+      <!-- <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff">
         <span>{{ $t('cfp') }}</span>
-      </nuxt-link>
-      <!-- <a href="https://scalaconfjp.doorkeeper.jp/events/103550" target="_blank" rel="noopener" class="banner_item banner_item-staff">
+      </nuxt-link> -->
+      <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener" class="banner_item banner_item-staff">
         <span>{{ $t('doorkeeper') }}</span>
-      </a> -->
+      </a>
     </div>
   </div>
 </template>

--- a/nuxt_src/pages/cfp/index.vue
+++ b/nuxt_src/pages/cfp/index.vue
@@ -118,7 +118,10 @@ ja:
 </template>
 
 <script>
+import Page404NotFoundMixin from '@/mixins/page/Page404NotFound.js'
+
 export default {
+  mixins: [Page404NotFoundMixin],
   head() {
     return {
       title: 'ScalaMatsuriに応募する',


### PR DESCRIPTION
## 変更点
- CFP 募集機関の終了に伴い、ヘッダのCFPページへのリンク&トップページのリンクを非表示に
- 同様の背景から、CFPページを 404 に (404にしちゃって大丈夫？？)
- Doorkeeper リンクの復活、および 2022 の ScalaMatsuri へ誘導するリンクへの置き換え

## Evidence




### CFP リンクの非表示 & Doorkeeper リンクの復活
|  Before  |  After |
| ---- | ---- |
| ![ScalaMatsuri_2022___The_largest_international_Scala_conference_in_Asia](https://user-images.githubusercontent.com/16359063/149661773-b052d141-4acc-4e4b-a7f1-d8eda38ea2fd.png) | ![ScalaMatsuri_2022___The_largest_international_Scala_conference_in_Asia](https://user-images.githubusercontent.com/16359063/149661754-39a968d2-b424-47a6-86fd-1b45f061a1bc.png)
|  ![ScalaMatsuri_2022___The_largest_international_Scala_conference_in_Asia](https://user-images.githubusercontent.com/16359063/149661860-1d6b198c-c8d4-4d7f-a41f-c71db1fe89dd.png) | ![Notification_Center](https://user-images.githubusercontent.com/16359063/149661877-e2a12be2-c2a2-481b-b767-27e864b7e65e.png) |
