### PR TITLE
Fix the overview for programs (English)

### DIFF
--- a/nuxt_src/pages/program/index.vue
+++ b/nuxt_src/pages/program/index.vue
@@ -8,8 +8,8 @@ en:
   to_candidates: To Proposals
   bookmark_only: BookMark Only
   day1_description: |
-    Conference DAY in conference format (3 parallel sessions). Doors open at 10:30, scheduled to end at 21:00 in JST.<br>
-    Simultaneous interpretation will be provided via Zoom Webinar for all Track A or B sessions.
+    Conference DAY in conference format. Doors open at 10:00, scheduled to end at 15:25 in JST.<br>
+    Simultaneous interpretation will be provided via Zoom Webinar for all sessions.
   day2_description: |
     Open Mic Conference DAY <a href="https://github.com/scalamatsuri/2022.unconference/projects/1" target="_blank" rel="noopener">Timetable</a>.<br>
     Doors open at 10:00, and scheduled to end at 15:25 in JST.<br>


### PR DESCRIPTION
The overview(en) didn't reflect this year's session structures.

## before
<img width="1116" alt="Screen Shot 2022-02-20 at 16 28 12" src="https://user-images.githubusercontent.com/9353584/154832918-a47e0e97-765d-4a80-b3e7-d2ddcc9eb31d.png">


## after
<img width="932" alt="Screen Shot 2022-02-20 at 16 28 04" src="https://user-images.githubusercontent.com/9353584/154832923-c3175461-8475-4ac8-ae89-046c7aa19625.png">

